### PR TITLE
Added a mock openGL context

### DIFF
--- a/tests/src/de/tomgrill/gdxtesting/GdxTestRunner.java
+++ b/tests/src/de/tomgrill/gdxtesting/GdxTestRunner.java
@@ -24,6 +24,10 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import static org.mockito.Mockito.mock;
+
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.headless.HeadlessApplication;
 import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
@@ -37,6 +41,7 @@ public class GdxTestRunner extends BlockJUnit4ClassRunner implements Application
 		HeadlessApplicationConfiguration conf = new HeadlessApplicationConfiguration();
 
 		new HeadlessApplication(this, conf);
+		Gdx.gl = mock(GL20.class);
 	}
 
 	@Override


### PR DESCRIPTION
To allow testing of classes that require a running openGL context (i.e. that use any graphical assets.)

https://stackoverflow.com/questions/25612660/creating-texture-in-headless-libgdx-unit-tests